### PR TITLE
Crunchy doc: fix typo

### DIFF
--- a/connect/crunchy_bridge.mdx
+++ b/connect/crunchy_bridge.mdx
@@ -9,7 +9,7 @@ Crunchy Bridge comes with logical replication enabled by [default](https://docs.
 ```sql
 SHOW wal_level; -- should be logical
 SHOW max_wal_senders; -- should be 10
-SHOW max_replication_slotsl; -- should be 10
+SHOW max_replication_slots; -- should be 10
 ```
 
 ## Creating PeerDB User and Granting permissions


### PR DESCRIPTION
```sql
SHOW max_replication_slotsl; -- should be 10
```

to:

```sql
SHOW max_replication_slots; -- should be 10
```
