### PR TITLE
mirror/upgrade.mdx: explain how to upgrade without resync

### DIFF
--- a/lua/reference.mdx
+++ b/lua/reference.mdx
@@ -95,7 +95,6 @@ Has properties for durations since Unix epoch. These are `[I64]` results, except
 ## `UUID`
 Index with `[0..16)` to access bytes *(first element at index 0)*
 ## `BigInt`
-`[BigInt]` implements `__len`. Indexing with a number accesses its bytes. If iterating all bytes you should store result of bytes property to avoid allocations
 #### `sign`
 `1`, `0`, or `-1` depending on sign of value
 #### `bytes`

--- a/mint.json
+++ b/mint.json
@@ -83,7 +83,8 @@
         "mirror/cdc-pg-bq",
         "mirror/cdc-pg-sf",
         "mirror/cdc-pg-pg",
-        "mirror/cdc-pg-clickhouse"
+        "mirror/cdc-pg-clickhouse",
+        "mirror/upgrade"
       ]
     },
     {

--- a/mirror/upgrade.mdx
+++ b/mirror/upgrade.mdx
@@ -1,0 +1,10 @@
+Usually, recreating mirrors is not necessary unless we made some sort of breaking change. Pausing the mirror, upgrading, and then resuming mitigates temporal non determinism.
+
+If the mirror for some reason after an upgrade is in a bad state, then the following procedure works, avoiding the need to resync:
+1. Terminate `yourmirror-peerflow` workflow in Temporal
+2. Run sql on PeerDB server: `delete from flows where name = 'yourmirror';`
+3. Create mirror with same name and other parameters, **but turn off initial copy**
+
+This works because PeerDB picks up the last flushed LSN from the replication slot (which we did not drop. Drop Mirror drops the slot so we can't do that) , and our final normalize step (for PG, BQ, SF, CH destinations) has a merge command which ensures there won't be duplicates.
+
+If you're upgrading during initial load, then what you would want to do is comment out flow-snapshot-worker in the docker compose or make sure it stays on the same earlier version. This worker is responsible for holding the CREATE REPLICATION SLOT connection open, so if it restarts then initial load fails.

--- a/mirror/upgrade.mdx
+++ b/mirror/upgrade.mdx
@@ -1,4 +1,4 @@
-Usually, recreating mirrors is not necessary unless we made some sort of breaking change. Pausing the mirror, upgrading, and then resuming mitigates temporal non determinism.
+Usually, recreating mirrors is not necessary unless there's been breaking changes. Pausing the mirror, upgrading, and then resuming mitigates temporal non determinism.
 
 If the mirror for some reason after an upgrade is in a bad state, then the following procedure works, avoiding the need to resync:
 1. Terminate `yourmirror-peerflow` workflow in Temporal


### PR DESCRIPTION
Amogh recently answered this question on Slack,
it was a pretty detailed yet clear response,
so figured we should record it for future reference