### PR TITLE
Update use case page: Postgres to Eventhubs

### DIFF
--- a/usecases/Real-time CDC/postgres-to-azure-eventhubs.mdx
+++ b/usecases/Real-time CDC/postgres-to-azure-eventhubs.mdx
@@ -30,28 +30,27 @@ Run the following commands to let PeerDB know about the existing PostgreSQL and 
 psql "port=9900 host=localhost password=peerdb"
 
 -- Add PostgreSQL and Event Hubs peers
-CREATE PEER postgres_peer FROM PostgreSQL (...);
-CREATE PEER eventhub_peer FROM EVENTHUB (...);
-CREATE PEER eventhub_group_peer FROM EVENTHUBGROUP (...);
+CREATE PEER postgres_peer FROM POSTGRES (...);
+CREATE PEER eventhubs_peer FROM EVENTHUBS (...);
 ```
 
-Make sure to replace **`(…)`** with the appropriate connection details for both the PostgreSQL and Event Hubs instances. More details on adding PEERs are available [here](/sql/commands/create-peer).
+Make sure to replace **`(…)`** with the appropriate connection details for both the PostgreSQL and Event Hubs instances. More details on adding Peers are available [here](/sql/commands/create-peer).
 
 ### **Step 2: Real-Time CDC from PostgreSQL to Event Hubs**
+The mirror from PostgreSQL to Eventhubs is unique, in the sense that you can sync source tables **across namespaces**, 
+and you can **specify a column whose values will be used to route data** into the partitions of the event hub.
 
 To facilitate real-time Change Data Capture (CDC) from PostgreSQL to Event Hubs, set up your peers and then create a mirror using the following SQL syntax:
 
 ```sql
 CREATE MIRROR IF NOT EXISTS <mirror-name>
-FROM <postgres-peer-name> TO <eventhubgroup-peer-name>
+FROM <postgres-peer-name> TO <eventhubs-peer-name>
 WITH TABLE MAPPING(
-    <source-schema>.<table>:<eh-group-member>.<destination-schema>.<table>,
+    <source-schema>.<table>:<namespace_name>.<eventhub_name>.<partition_key_column>,
     ... -- Repeat as required for multiple tables
 )
 WITH(
     max_batch_size = <number>,
-    push_batch_size = <number>,
-    push_parallelism = <number>,
     publication_name = '<publication-name>'
 );
 ```
@@ -62,14 +61,13 @@ Example:
 CREATE MIRROR IF NOT EXISTS test_eh_mirror
 FROM test_pg_peer TO test_eh_peer
 WITH TABLE MAPPING(
-    schema1.table1:eh_group_member_1.hub1.table1,
-    schema1.table2:eh_group_member_1.hub1.table2
+    schema1.table1:mynamespace1.hub1.id,
+    schema1.table2:mynamespace2.hub2.id
     -- Add more tables as required
 )
 WITH(
+    do_initial_copy = false,
     max_batch_size = 300000,
-    push_batch_size = 300000,
-    push_parallelism = 32,
     publication_name = 'test_publication'
 );
 ```
@@ -78,11 +76,12 @@ Parameters:
 
 - **`mirror-name`**: Desired name for the mirror.
 - **`postgres-peer-name`**: Name of the PostgreSQL peer.
-- **`eventhubgroup-peer-name`**: Name of the Event Hubs group peer.
-- **max_batch_size**: Maximum number of records in a batch.
-- **push_batch_size**: Number of records to push in a batch.
-- **push_parallelism**: Degree of parallelism for data pushes.
-- **publication_name**: Name of the publication.
+- **`eventhubs-peer-name`**: Name of the Event Hubs group peer.
+- **`namespace-name`**: Name of the namespace in which you wish to sync to an eventhub.
+- **`eventhub-name`**: Name of the eventhub in which you wish to sync the data. PeerDB creates the eventhub for you if it doesn't exist already.
+- **`partition_key_column`**: Column in the source table whose values will be used to route data into the partitions of the event hub.
+- **`max_batch_size`**: Maximum number of records in a batch.
+- **`publication_name`**: Name of the publication.
 
 Remember to adjust placeholder values (\<...\>) with your specific details and preferences.
 The example above has been abbreviated for clarity; ensure you provide all the necessary mappings and configurations in practice.

--- a/usecases/Real-time CDC/postgres-to-bigquery.mdx
+++ b/usecases/Real-time CDC/postgres-to-bigquery.mdx
@@ -63,7 +63,7 @@ To perform CDC via AVRO mode, you must set the following:
 
 If you observe, **TABLE MAPPING** represents the table name mapping between the two Postgres peers. The final `WITH` clause captures if you wanted to include initial snapshot as a part of the MIRROR. If you don't include that `WITH`, peerdb assumes that you don't want to perform an initial snapshot. If just reads the slot and replays the changes to the target.
 
-1. Data type mapping between [Postgres and BigQuery](https://github.com/PeerDB-io/peerdb/pull/89#issue-1737252747).
+1. Data type mapping between [Postgres and BigQuery](/datatypes/datatype-matrix).
 2. If you want additional types to be supported or want to alter the existing data type mapping, please reach out to us. We can aim to support that within a few days. Also, PeerDB is [fully open source](https://github.com/PeerDB-io/peerdb), so feel free to submit a PR.
 
 > **PeerDB also supports replicating TOAST columns very efficiently**. Unlike most CDC tools, you don't need to set up REPLICA IDENTITY FULL for replicating TOAST columns. This [PR](https://github.com/PeerDB-io/peerdb/pull/111) captures the infrastructural optimizations that PeerDB takes to support TOAST columns.

--- a/usecases/Real-time CDC/postgres-to-snowflake.mdx
+++ b/usecases/Real-time CDC/postgres-to-snowflake.mdx
@@ -87,7 +87,7 @@ To perform CDC via `AVRO mode`, you must set the following:
 You must set the staging path to be an existing S3 bucket URL, or an empty string for PeerDB to stage the AVRO files internally.
 
 If you observe, **TABLE MAPPING** represents the table name mapping between the two Postgres peers. The final `WITH` clause captures if you wanted to include initial snapshot as a part of the MIRROR. If you don't include that `WITH`, PeerDB assumes that you don't want to perform an initial snapshot. If just reads the slot and replays the changes to the target.
-1. Data type mapping between [Postgres and Snowflake can be found here](https://github.com/PeerDB-io/peerdb/pull/104).
+1. Data type mapping between [Postgres and Snowflake can be found here](/datatypes/datatype-matrix).
 2. If you want additional types to be supported or want to alter the existing data type mapping, please reach out to us. We can aim to support that within a few days. Also, PeerDB is [fully open source](https://github.com/PeerDB-io/peerdb), so feel free to submit a PR.
 
 > **PeerDB also supports replicating TOAST columns very efficiently**. Unlike most CDC tools, you don't need to set up REPLICA IDENTITY FULL for replicating TOAST columns. This [PR](https://github.com/PeerDB-io/peerdb/pull/111) captures the infrastructural optimizations that PeerDB takes to support TOAST columns.


### PR DESCRIPTION
Adapts this page to use the new peer and mirror structure for Eventhubs
Also there were a couple of links for data type mapping for bigquery and snowflake in the use cases section. They were pointing to old PRs. This PR routes them to the data type matrix page