### PR TITLE
Update create mirror cdc SQL command

### DIFF
--- a/sql/commands/create-mirror.mdx
+++ b/sql/commands/create-mirror.mdx
@@ -57,21 +57,6 @@ This is optional as PeerDB creates the slot it needs by default. A use-case for 
 10. **synced_at_col_name**: Column name to be used for tracking the last synced timestamp. Default is `_PEERDB_SYNCED_AT`.
 11. **soft_delete_col_name**: Column name to be used for tracking the soft delete status. Default is `_PEERDB_IS_DELETED`.
 
-
-#### CDC Modes for Mirror
-
-We also support the `sql` and `avro` modes for CDC for some destinations such as BigQuery and Snowflake. This can be configured with:
-
-```
-  cdc_sync_mode = 'avro' // or 'sql'
-  cdc_staging_path = '<stage>' // Needed for AVRO mode only
-```
-
-The stage depends on your destination peer:
-
-- For BigQuery, it would be your GCS bucket.
-- For Snowflake, it would be either your S3 bucket URL or an empty string for PeerDB to stage AVRO files internally.
-
 ### MIRROR for Streaming Query Results
 
 This type of MIRROR periodically streams query results on the source peer to the target peer.

--- a/sql/commands/create-mirror.mdx
+++ b/sql/commands/create-mirror.mdx
@@ -9,8 +9,12 @@ PeerDB introduces CREATE MIRROR command for blazing fast syncs between Peers. Th
 
 ### MIRROR for CDC
 
-This type of MIRROR streams change feed in real-time from source peer to target peer. For BigQuery, Snowflake and Postgres destinations specifically, we also support automatic propagation of table schema changes. Any new column detected in the source tables will be created in the corresponding destination table, and rows with the new columns will be transferred as well. Dropped columns in the source tables are currently ignored.
-
+This type of MIRROR streams change feed in real-time from source peer to target peer.
+The table mapping section supports two syntaxes, show below, and both can be used in the same mapping.
+The second syntax with the JSON-like structure is useful when you want to exclude certain columns from the sync with `exclude:[]`
+<Info>
+Note that for BigQuery and Clickhouse mirrors, the target tables should not be schema qualified.
+</Info>
 ```sql
 CREATE MIRROR [IF NOT EXISTS] <mirror_name>
 FROM <source_peer> TO <target_peer>
@@ -21,32 +25,44 @@ WITH TABLE MAPPING
   {
     from: <schema_name>.<source_table_name>,
     to: <schema_name>.<target_table_name>,
-    key: <partition_key>
-  } -- syntax only for EventHub peers
+    exclude: [column1, column2 ,column3...]
+  }
 )
 WITH (
-  do_initial_copy = <include_initial_copy>,
-  snapshot_sync_mode='<sql_or_avro>',
-  snapshot_num_rows_per_partition = <500000>,
+  do_initial_copy = <true|false>, -- required
+  max_batch_size = <max_batch_size>,
+  sync_interval = <sync_interval>,
+  publication_name = '<publication_name>',
+  replication_slot_name = '<replication_slot_name>', -- applicable only when do_initial_copy is false
+  snapshot_num_rows_per_partition = <number_of_rows_in_each_partition>,
   snapshot_max_parallel_workers = <number_of_threads_per_table>,
-  snapshot_num_tables_in_parallel = <number_of_tables_in_parallel>
+  snapshot_num_tables_in_parallel = <number_of_tables_in_parallel>,
+  soft_delete = <true|false>,
+  synced_at_col_name = '<column_name>',
+  soft_delete_col_name = '<column_name>'
 );
 ```
 
 1. **do_initial_copy**: `true` if you want to include initial snapshot of tables as a part of the MIRROR, else `false`.
-2. **snapshot_sync_mode**: `sql` uses a multi-insert command and `avro` converts data to avro format before syncing to target. Both use the COPY command under the covers. `avro` is the only supported mode for Snowflake destinations and `sql` is the only supported mode for Postgres destinations.
-3. **snapshot_num_tables_in_parallel**: In the initial snapshot, number of tables to be snapshotted at parallely.
-4. **snapshot_max_parallel_workers**: In the initial snapshot, number of threads used per table. Max number of concurrent connections on source will be `snapshot_num_tables_in_parallel*snapshot_max_parallel_workers`
-5. **snapshot_num_rows_per_partition**: In the initial snapshot, number of rows per table streamed in a given batch.
-6. If **key** is specified, the table will be partitioned on the target peer based on the partition_key. If not specified, the table will be partitioned on the target peer based on the `ctid` column.
-7. `if_not_exists`: If specified, the MIRROR will be created only if it does not exist.
+2. **max_batch_size**: Maximum number of rows to be synced in a single batch.
+3. **sync_interval**: Interval in seconds at which the mirror should sync the changes.
+4. **publication_name**: Name of the publication on the source peer. This is optional as PeerDB creates the publication it needs anyway.
+By creating a publication and providing it here, however, you do not need to provide write access to the database and tables (since that's needed for PeerDB to create the publication).
+5. **replication_slot_name**: Name of the replication slot on the source peer. Do not set this if initial load is enabled.
+This is optional as PeerDB creates the slot it needs by default. A use-case for this setting is when you want to resume a change-data capture from an existing replication slot.
+6. **snapshot_num_tables_in_parallel**: In the initial snapshot, number of tables to be snapshotted at in parallel.
+7. **snapshot_num_rows_per_partition**: In the initial snapshot, PeerDB divides the rows of each table into partitions of these many rows, and syncs those partitions.
+8. **snapshot_max_parallel_workers**: In the initial snapshot, number of threads used per table. Max number of concurrent connections on source will be `snapshot_num_tables_in_parallel * snapshot_max_parallel_workers`
+9. **soft_delete**: `true` if you want to soft delete rows on the target peer when they are deleted on the source peer.
+10. **synced_at_col_name**: Column name to be used for tracking the last synced timestamp. Default is `_PEERDB_SYNCED_AT`.
+11. **soft_delete_col_name**: Column name to be used for tracking the soft delete status. Default is `_PEERDB_IS_DELETED`.
+
 
 #### CDC Modes for Mirror
 
 We also support the `sql` and `avro` modes for CDC for some destinations such as BigQuery and Snowflake. This can be configured with:
 
 ```
-
   cdc_sync_mode = 'avro' // or 'sql'
   cdc_staging_path = '<stage>' // Needed for AVRO mode only
 ```


### PR DESCRIPTION
Adds a lot of information and missing settings for the create mirror cdc section. 
This includes pull batch size and sync interval, publication name etc
Also explains nuances of replication slot name and publication name
Also explains the two syntaxes in table mapping