### PR TITLE
API Documentation: Boilerplate, 2 endpoints

### DIFF
--- a/api/endpoints/custom-sync.mdx
+++ b/api/endpoints/custom-sync.mdx
@@ -1,4 +1,3 @@
-## Resume a mirror with specified number of syncs
 
 ```http
 POST /api/mirrors/sync
@@ -59,7 +58,7 @@ curl --request POST \
 }
 ```
 
-```bash Error example
+```json Error example
 {
 	"flowJobName": "testing_bq_2",
 	"numberOfSyncs": 0,

--- a/api/endpoints/custom-sync.mdx
+++ b/api/endpoints/custom-sync.mdx
@@ -1,0 +1,70 @@
+## Resume a mirror with specified number of syncs
+
+```http
+POST /api/mirrors/sync
+```
+
+This endpoint is used to resume a [paused](/features/pause-mirror) mirror and
+trigger a specified number of syncs before the mirror pauses again.
+
+The mirror must be paused for this endpoint to work.
+
+### Request Fields
+<ParamField path="flowJobName" type="string" required>
+The name of the mirror to be resumed.
+</ParamField>
+
+<ParamField path="numberOfSyncs" type="number" required>
+The number of syncs to run before the mirror pauses again.
+Must be less than **32**.
+</ParamField>
+
+### Response Fields
+<ParamField path="flowJobName" type="string">
+The name of the mirror that was resumed.
+</ParamField>
+
+<ParamField path="numberOfSyncs" type="number">
+The number of syncs that are going to be run.
+</ParamField>
+
+<ParamField path="errorMessage" type="string">
+Error message if any.
+</ParamField>
+
+<ParamField path="ok" type="boolean">
+Indicates if the request was successful.
+</ParamField>
+
+<RequestExample>
+```bash Request
+curl --request POST \
+  --url http://localhost:3000/api/mirrors/sync \
+  --header 'Authorization: Basic OnBlZXJkYg==' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"flowJobName":"testing_bq_2",
+	"numberOfSyncs":4
+}'
+```
+</RequestExample>
+
+<ResponseExample>
+```json
+{
+	"flowJobName": "testing_bq_2",
+	"numberOfSyncs": 4,
+	"errorMessage": "",
+	"ok": true
+}
+```
+
+```bash Error example
+{
+	"flowJobName": "testing_bq_2",
+	"numberOfSyncs": 0,
+	"errorMessage": "Requested mirror testing_bq_2 is not paused. This is a requirement.\n\t\tThe mirror can be paused via PeerDB UI. Please follow https://docs.peerdb.io/features/pause-mirror",
+	"ok": false
+}
+```
+</ResponseExample>

--- a/api/endpoints/mirror-status.mdx
+++ b/api/endpoints/mirror-status.mdx
@@ -74,29 +74,23 @@ Information about the mirror configuration and initial load of tables.
             </Expandable>
             </ResponseField>
             <ResponseField name="maxBatchSize" type="number">
-            Pull batch size: the number of rows to pull in a single batch.
+            Pull batch size: the maximum number of rows to pull in a single batch, if `idleTimeoutSeconds` has not been reached.
             </ResponseField>
             <ResponseField name="idleTimeoutSeconds" type="string">
             The time in seconds after which the mirror will flush pulled rows to the target data store,
             if pull batch size has not already been reached.
             </ResponseField>
-            <ResponseField name="cdcStagingPath" type="string">
-            The path where CDC staging files are stored.
-            </ResponseField>
             <ResponseField name="publicationName" type="string">
-            The publication name in the source database.
+            User provided publication name for the mirror, if any.
             </ResponseField>
             <ResponseField name="replicationSlotName" type="string">
-            The replication slot name in the source database.
+            User provided replication slot name for the mirror, if any.
             </ResponseField>
             <ResponseField name="doInitialSnapshot" type="boolean">
-            Indicates if an initial snapshot is to be taken.
+            Indicates if initial snapshot was enabled for this mirror.
             </ResponseField>
             <ResponseField name="snapshotNumRowsPerPartition" type="number">
             The number of rows to sync per partition during initial snapshot.
-            </ResponseField>
-            <ResponseField name="snapshotStagingPath" type="string">
-            The path where initial snapshot staging files are stored.
             </ResponseField>
             <ResponseField name="snapshotMaxParallelWorkers" type="number">
             The maximum number of parallel workers to use during initial snapshot.
@@ -105,10 +99,10 @@ Information about the mirror configuration and initial load of tables.
             The number of tables to sync in parallel during initial snapshot.
             </ResponseField>
             <ResponseField name="resync" type="boolean">
-            Indicates if a resync is to be performed.
+            Indicates if this mirror is a resync
             </ResponseField>
             <ResponseField name="initialSnapshotOnly" type="boolean">
-            Indicates if only an initial snapshot is to be taken.
+            Indicates if this mirror was configured to only run initial load and not CDC.
             </ResponseField>
             <ResponseField name="softDelete" type="boolean">
             Indicates if soft delete is enabled.
@@ -120,7 +114,7 @@ Information about the mirror configuration and initial load of tables.
             The name of the column used for tracking sync time.
             </ResponseField>
             <ResponseField name="script" type="string">
-            The script to run after each sync.
+            Lua script configured for the mirror.
             </ResponseField>
             <ResponseField name="system" type="Q | PG">
             The data type system of the mirror.
@@ -136,10 +130,11 @@ Information about the mirror configuration and initial load of tables.
                 Information about the initial load of tables.
             <Expandable>
                 <ResponseField name="clones" type="object array">
-                Array of clone objects. Each object contains the following fields.
+                Array of clone objects - each indicating initial load information of a table.
+                Each object contains the following fields.
                 <Expandable>
                     <ParamField path="tableName" type="string">
-                    The name of the table.
+                    The name of the destination table.
                     </ParamField>
                     <ParamField path="startTime" type="string">
                     The time when the clone started.
@@ -154,10 +149,10 @@ Information about the mirror configuration and initial load of tables.
                     The number of rows synced.
                     </ParamField>
                     <ParamField path="avgTimePerPartitionMs" type="string">
-                    The average time per partition in milliseconds.
+                    The average time taken to sync each partition, in milliseconds.
                     </ParamField>
                     <ParamField path="flowJobName" type="string">
-                    The name of the clone flow.
+                    The name of the clone job.
                     </ParamField>
                     <ParamField path="sourceTable" type="string">
                     The source table.
@@ -166,7 +161,7 @@ Information about the mirror configuration and initial load of tables.
                     Indicates if fetching is completed.
                     </ParamField>
                     <ParamField path="consolidateCompleted" type="boolean">
-                    Indicates if consolidation is completed.
+                    Indicates if consolidation (loading of stage files to target tables) is completed.
                     </ParamField>
                     <ParamField path="mirrorName" type="string">
                     The name of the mirror.

--- a/api/endpoints/mirror-status.mdx
+++ b/api/endpoints/mirror-status.mdx
@@ -1,0 +1,292 @@
+
+```http
+POST /api/mirrors/state
+```
+
+This endpoint is used to get the status of a mirror. Status of the mirror could be:
+
+- `STATUS_SETUP`: The mirror is in setup flow, where it creates target tables and metadata tables.
+- `STATUS_SNAPSHOT`: The mirror is currently performing initial load.
+- `STATUS_RUNNING`: The mirror has completed initial load and is in the phase of CDC.
+- `STATUS_PAUSED`: The mirror is in CDC phase and is [paused](/features/pause-mirror).
+- `STATUS_PAUSING`: The mirror is in CDC phase and is in the process of pausing.
+- `STATUS_TERMINATED`: The mirror has been deleted/terminated.
+- `STATUS_UNKNOWN`: The mirror is not found in the catalog, or its status cannot be obtained due to some issue.
+
+### Request Body
+The request consists of the mirror name specified as `flowJobName`
+and `includeFlowInfo` as a boolean, which when set, will include in its response
+additional, non-status related information about the mirror
+such as mirror configuration and initial load information of tables.
+
+<ParamField path="flowJobName" type="string" required>
+The name of the mirror to get the status of.
+</ParamField>
+
+<ParamField path="includeFlowInfo" type="boolean">
+When set to true, will include in its response
+additional, non-status related information about the mirror
+such as mirror configuration and initial load information of tables.
+</ParamField>
+
+### Response Fields
+
+<ParamField path="flowJobName" type="string">
+The name of the mirror.
+</ParamField>
+
+<ParamField path="errorMessage" type="string">
+Error message if any.
+</ParamField>
+
+<ParamField path="currentFlowState" type="string">
+The current state of the mirror.
+</ParamField>
+
+<ParamField path="ok" type="boolean">
+Indicates if the request was successful.
+</ParamField>
+
+Additional flow information when `includeFlowInfo` is set to true:
+<Expandable>
+<ResponseField name="cdcStatus" type="object">
+Information about the mirror configuration and initial load of tables.
+    <Expandable title='config'>
+        <ResponseField name="config" type="object">
+        Mirror configuration.
+        </ResponseField>
+        <Expandable>
+            <ResponseField name="flowJobName" type="string">
+            The name of the mirror.
+            </ResponseField>
+            <ResponseField name="tableMappings" type="object array">
+            Array of table mapping objects. Each object contains the following fields.
+            <Expandable>
+                <ParamField path="sourceTableIdentifier" type="string">
+                The source table identifier. Will be of the form `schema.table`.
+                </ParamField>
+                <ParamField path="destinationTableIdentifier" type="string">
+                The destination table identifier.
+                </ParamField>
+                <ParamField path="exclude" type="string array">
+                Column names to exclude
+                </ParamField>
+            </Expandable>
+            </ResponseField>
+            <ResponseField name="maxBatchSize" type="number">
+            Pull batch size: the number of rows to pull in a single batch.
+            </ResponseField>
+            <ResponseField name="idleTimeoutSeconds" type="string">
+            The time in seconds after which the mirror will flush pulled rows to the target data store,
+            if pull batch size has not already been reached.
+            </ResponseField>
+            <ResponseField name="cdcStagingPath" type="string">
+            The path where CDC staging files are stored.
+            </ResponseField>
+            <ResponseField name="publicationName" type="string">
+            The publication name in the source database.
+            </ResponseField>
+            <ResponseField name="replicationSlotName" type="string">
+            The replication slot name in the source database.
+            </ResponseField>
+            <ResponseField name="doInitialSnapshot" type="boolean">
+            Indicates if an initial snapshot is to be taken.
+            </ResponseField>
+            <ResponseField name="snapshotNumRowsPerPartition" type="number">
+            The number of rows to sync per partition during initial snapshot.
+            </ResponseField>
+            <ResponseField name="snapshotStagingPath" type="string">
+            The path where initial snapshot staging files are stored.
+            </ResponseField>
+            <ResponseField name="snapshotMaxParallelWorkers" type="number">
+            The maximum number of parallel workers to use during initial snapshot.
+            </ResponseField>
+            <ResponseField name="snapshotNumTablesInParallel" type="number">
+            The number of tables to sync in parallel during initial snapshot.
+            </ResponseField>
+            <ResponseField name="resync" type="boolean">
+            Indicates if a resync is to be performed.
+            </ResponseField>
+            <ResponseField name="initialSnapshotOnly" type="boolean">
+            Indicates if only an initial snapshot is to be taken.
+            </ResponseField>
+            <ResponseField name="softDelete" type="boolean">
+            Indicates if soft delete is enabled.
+            </ResponseField>
+            <ResponseField name="softDeleteColName" type="string">
+            The name of the column used for soft delete.
+            </ResponseField>
+            <ResponseField name="syncedAtColName" type="string">
+            The name of the column used for tracking sync time.
+            </ResponseField>
+            <ResponseField name="script" type="string">
+            The script to run after each sync.
+            </ResponseField>
+            <ResponseField name="system" type="Q | PG">
+            The data type system of the mirror.
+            </ResponseField>
+            <ResponseField name="sourceName" type="string">
+            The source peer name.
+            </ResponseField>
+            <ResponseField name="destinationName" type="string">
+            The destination peer name.
+            </ResponseField>
+        </Expandable>
+            <ResponseField name="snapshotStatus" type="object">
+                Information about the initial load of tables.
+            <Expandable>
+                <ResponseField name="clones" type="object array">
+                Array of clone objects. Each object contains the following fields.
+                <Expandable>
+                    <ParamField path="tableName" type="string">
+                    The name of the table.
+                    </ParamField>
+                    <ParamField path="startTime" type="string">
+                    The time when the clone started.
+                    </ParamField>
+                    <ParamField path="numPartitionsCompleted" type="number">
+                    The number of partitions completed.
+                    </ParamField>
+                    <ParamField path="numPartitionsTotal" type="number">
+                    The total number of partitions.
+                    </ParamField>
+                    <ParamField path="numRowsSynced" type="string">
+                    The number of rows synced.
+                    </ParamField>
+                    <ParamField path="avgTimePerPartitionMs" type="string">
+                    The average time per partition in milliseconds.
+                    </ParamField>
+                    <ParamField path="flowJobName" type="string">
+                    The name of the clone flow.
+                    </ParamField>
+                    <ParamField path="sourceTable" type="string">
+                    The source table.
+                    </ParamField>
+                    <ParamField path="fetchCompleted" type="boolean">
+                    Indicates if fetching is completed.
+                    </ParamField>
+                    <ParamField path="consolidateCompleted" type="boolean">
+                    Indicates if consolidation is completed.
+                    </ParamField>
+                    <ParamField path="mirrorName" type="string">
+                    The name of the mirror.
+                    </ParamField>
+                </Expandable>
+                </ResponseField>
+            </Expandable>
+        </ResponseField>
+        <ResponseField name="sourceType" type="string">
+        The source peer type. Example:  `"POSTGRES"`
+        </ResponseField>
+        <ResponseField name="destinationType" type="string">
+        The destination peer type. Example: `"BIGQUERY"`
+        </ResponseField>
+    </Expandable>
+
+</ResponseField>
+</Expandable>
+
+<RequestExample>
+```bash Request
+curl --request POST \
+  --url http://localhost:3000/api/mirrors/state \
+  --header 'Authorization: Basic OnBlZXJkYg==' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	`flowJobName`:`testing_bq_2`,
+	`includeFlowInfo`:false
+}'
+```
+
+```bash with includeFlowInfo set
+curl --request POST \
+  --url http://localhost:3000/api/mirrors/state \
+  --header 'Authorization: Basic OnBlZXJkYg==' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	`flowJobName`:`testing_bq_2`,
+	`includeFlowInfo`:true
+}'
+```
+</RequestExample>
+
+<ResponseExample>
+```json Response
+{
+	"flowJobName": "testing_bq_2",
+	"errorMessage": "",
+	"currentFlowState": "STATUS_RUNNING",
+	"ok": true
+}
+```
+
+```json with includeFlowInfo set
+{
+	"flowJobName": "testing_bq_2",
+	"cdcStatus": {
+		"config": {
+			"flowJobName": "testing_bq_2",
+			"tableMappings": [
+				{
+					"sourceTableIdentifier": "public.sales",
+					"destinationTableIdentifier": "public_sales",
+					"partitionKey": "",
+					"exclude": [] // excluded columns, comma-separated
+				},
+			],
+			"maxBatchSize": 1000000,
+			"idleTimeoutSeconds": "60",
+			"cdcStagingPath": "",
+			"publicationName": "",
+			"replicationSlotName": "",
+			"doInitialSnapshot": true,
+			"snapshotNumRowsPerPartition": 1000000,
+			"snapshotStagingPath": "",
+			"snapshotMaxParallelWorkers": 4,
+			"snapshotNumTablesInParallel": 1,
+			"resync": false,
+			"initialSnapshotOnly": false,
+			"softDelete": true,
+			"softDeleteColName": "_PEERDB_IS_DELETED",
+			"syncedAtColName": "_PEERDB_SYNCED_AT",
+			"script": "",
+			"system": "Q",
+			"sourceName": "postgres_local",
+			"destinationName": "bq_peer"
+		},
+		"snapshotStatus": {
+			"clones": [
+				{
+					"tableName": "public_sales",
+					"startTime": "2024-06-27T14:37:48.701204Z",
+					"numPartitionsCompleted": 1,
+					"numPartitionsTotal": 1,
+					"numRowsSynced": "4",
+					"avgTimePerPartitionMs": "11381",
+					"flowJobName": "clone_testing_bq_2_public_sales_dc500df7_2606_4c19_96c0_e40e0df4e5ec",
+					"sourceTable": "public.sales",
+					"fetchCompleted": true,
+					"consolidateCompleted": true,
+					"mirrorName": "testing_bq_2"
+				}
+			]
+		},
+		"cdcSyncs": [], // coming soon
+		"sourceType": "POSTGRES",
+		"destinationType": "BIGQUERY"
+	},
+	"errorMessage": "",
+	"currentFlowState": "STATUS_RUNNING",
+	"ok": true
+}
+```
+
+```json Error example
+{
+	"flowJobName": "fake_mirror",
+	"errorMessage": "unable to get the workflow ID of mirror fake_mirror",
+	"currentFlowState": "STATUS_UNKNOWN",
+	"ok": false
+}
+```
+</ResponseExample>

--- a/api/reference.mdx
+++ b/api/reference.mdx
@@ -1,0 +1,55 @@
+---
+title: PeerDB API Reference
+---
+
+PeerDB provides multiple API endpoints to interact with it through the UI endpoint as a proxy.
+This is an ongoing effort to eventually expose all of PeerDB's functionality in the form of API endpoints for programmatic use-cases.
+
+## Base endpoint
+The base endpoint is the URL of PeerDB UI.
+
+**PeerDB OSS**
+
+When running PeerDB OSS on Docker, PeerDB UI is exposed at:
+```
+http://localhost:3000
+```
+
+**PeerDB Cloud**
+
+When using PeerDB Cloud, the URL is provided as part of the PeerDB instance you purchase.
+
+## Authentication
+
+PeerDB API uses basic authentication.
+The username is empty and the password is the same password used to login to PeerDB UI.
+
+<CodeGroup>
+
+```bash cURL
+curl --request POST \
+  --url http://localhost:3000/api/mirrors/state \
+  --header
+    'Authorization
+    : Basic
+    OnBlZXJkYg==' \
+--header
+    'Content-Type
+    : application/json' \
+```
+
+```javascript Axios
+axios.post('http://localhost:3000/api/mirrors/state', {}, {
+  headers: {
+    'Authorization': 'Basic OnBlZXJkYg==',
+    'Content-Type': 'application/json'
+  }
+})
+```
+</CodeGroup>
+
+## API Endpoints
+
+1. [Fetching mirror status](/api/endpoints/mirror-status)
+2. [Trigger a specified number of syncs](/api/endpoints/custom-sync)
+

--- a/mint.json
+++ b/mint.json
@@ -22,6 +22,11 @@
       "url": "sql"
     },
     {
+      "name": "API Reference",
+      "icon": "browser",
+      "url": "api"
+    },
+    {
       "name": "Lua Reference",
       "icon": "file-code",
       "url": "lua"
@@ -199,6 +204,14 @@
         "sql/commands/create-peer",
         "sql/commands/create-mirror",
         "sql/commands/supported-connectors"
+      ]
+    },
+    {
+      "group": "API Endpoints",
+      "pages": [
+        "api/reference",
+        "api/endpoints/custom-sync",
+        "api/endpoints/mirror-status"
       ]
     },
     {


### PR DESCRIPTION
This PR adds a section for API documentation, with 2 endpoints - mirror status and custom sync - outlined in detail
