### PR TITLE
add regionwise public IPs whitelist table and adapt existing references

### DIFF
--- a/connect/postgres/azure_flexible_server_postgres.mdx
+++ b/connect/postgres/azure_flexible_server_postgres.mdx
@@ -35,7 +35,7 @@ Anything on or after Postgres 12
 
 If you are using **PeerDB Cloud**, please follow the below steps to add peerdb ips to your network.
 
-1. Go to the **Networking** tab and add the 3 IPs `100.21.65.249`, `54.213.107.162` and `54.201.178.203` to Firewall 
+1. Go to the **Networking** tab and add the [public IPs of your PeerDB Cloud instance](/peerdb-cloud/ip-table) to the Firewall
 
 <Frame caption="Add PeerDB IPs to Firewall">
     <img src="/images/setup/flexible_server/firewall.png" />
@@ -46,27 +46,27 @@ If you are using **PeerDB Cloud**, please follow the below steps to add peerdb i
 Connect to your Azure Flexible Server Postgrees through the admin user and run the below commands:
 
 1. Create a Postgres user for exclusively PeerDB.
-    
+
     1. ```sql
               CREATE USER peerdb_user PASSWORD 'some-password';
         ```
-        
+
 2. Provide read-only access to the schema from which you are replicating tables to the `peerdb-user`. Below example shows setting up permissions for the `public` schema. If you want to grant access to multiple schemas, you can run these three commands for each schema.
-    
+
     1. ```sql
               GRANT USAGE ON SCHEMA "public" TO peerdb_user;
               GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO peerdb_user;
               ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO peerdb_user;
         ```
-        
+
 3. Grant replication access to this user:
-    
+
     1. ```sql
            ALTER ROLE peerdb_user REPLICATION;
         ```
-        
+
 4. Create publication that you'll be using for creating the MIRROR (replication) in future.
-    
+
     1. ```sql
               CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
         ```

--- a/connect/postgres/cloudsql_postgres.mdx
+++ b/connect/postgres/cloudsql_postgres.mdx
@@ -17,9 +17,9 @@ Anything on or after Postgres 12
 <Frame caption="Edit Button in CloudSQL Postgres">
     <img src="/images/setup/cloudsql_postgres/edit.png" />
 </Frame>
-    
+
 2. Go to Flags and change `cloudsql.logical_decoding` to on and `wal_sender_timeout` to 0. These changes will need restarting your Postgres server.
-    
+
 
 <Frame caption="Change cloudsql.logical_decoding to on">
     <img src="/images/setup/cloudsql_postgres/cloudsql_logical_decoding1.png" />
@@ -36,10 +36,10 @@ Anything on or after Postgres 12
 
 ## Add PeerDB Cloud IPs to Firewall
 
-If you are using **PeerDB Cloud**, please follow the below steps to add peerdb ips to your network.
+If you are using **PeerDB Cloud**, please follow the below steps to add PeerDB IPs to your network.
 
 1. Go to **Connections** section
-    
+
 <Frame caption="CloudSQL Connection Connection Section">
     <img src="/images/setup/cloudsql_postgres/connections.png" />
 </Frame>
@@ -50,7 +50,7 @@ If you are using **PeerDB Cloud**, please follow the below steps to add peerdb i
     <img src="/images/setup/cloudsql_postgres/coconnections_networking.png" />
 </Frame>
 
-3. Add 3 networks for the IPs `100.21.65.249`, `54.213.107.162` and `54.201.178.203`
+3. Add the [public IPs of your PeerDB Cloud instance](/peerdb-cloud/ip-table)
 
 <Frame caption="Add PeerDB Networks">
     <img src="/images/setup/cloudsql_postgres/firewall1.png" />
@@ -65,31 +65,31 @@ If you are using **PeerDB Cloud**, please follow the below steps to add peerdb i
 Connect to your CloudSQL Postgres through the admin user and run the below commands:
 
 1. Create a Postgres user for exclusively PeerDB.
-    
+
     1. ```sql
               CREATE USER peerdb_user PASSWORD 'some-password';
         ```
-        
+
 2. Provide read-only access to the schema from which you are replicating tables to the `peerdb-user`. Below example shows setting up permissions for the `public` schema. If you want to grant access to multiple schemas, you can run these three commands for each schema.
-    
+
     1. ```sql
               GRANT USAGE ON SCHEMA "public" TO peerdb_user;
               GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO peerdb_user;
               ALTER DEFAULT PRIVILEGES IN SCHEMA "public" GRANT SELECT ON TABLES TO peerdb_user;
         ```
-        
+
 3. Grant replication access to this user:
-    
+
     1. ```sql
            ALTER ROLE peerdb_user REPLICATION;
         ```
-        
+
 4. Create publication that you'll be using for creating the MIRROR (replication) in future.
-    
+
     1. ```sql
               CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
         ```
-        
+
 <SSHTunnel />
 
 ## Create CloudSQL Postgres Peer in PeerDB

--- a/connect/postgres/crunchy_bridge.mdx
+++ b/connect/postgres/crunchy_bridge.mdx
@@ -46,7 +46,7 @@ Connect to your Crunchy Bridge Postgres through the `postgres` user and run the 
 
 ## Safe list PeerDB Cloud IPs
 
-If you are using PeerDB Cloud please safe list PeerDB IPs (`100.21.65.249`, `54.213.107.162` and `54.201.178.203`) by adding the Firewall Rules in Crunchy Bridge.
+If you are using PeerDB Cloud [safelist the public IPs of your PeerDB Cloud instance](/peerdb-cloud/ip-table) by adding the Firewall Rules in Crunchy Bridge.
 
 <Frame caption="Where to find Firewall Rules in Crunchy Bridge?">
 <img src="/images/setup/firewall_rules_crunchy_bridge.png" />

--- a/connect/postgres/rds_postgres.mdx
+++ b/connect/postgres/rds_postgres.mdx
@@ -77,7 +77,7 @@ Connect to your RDS postgres through the admin user and run the below commands:
 
 ## Safe list PeerDB Cloud IPs
 
-If you are using PeerDB Cloud please safe list PeerDB IPs (`100.21.65.249`, `54.213.107.162` and `54.201.178.203`) by editing the `Inbound rules` of the `Security group` in which your RDS Postgres is located.
+If you are using PeerDB Cloud [safelist public IPs of your PeerDB Cloud instance](/peerdb-cloud/ip-table) by editing the `Inbound rules` of the `Security group` in which your RDS Postgres is located.
 
 <Frame caption="Where to find security group in RDS Postgres?">
 <img src="/images/setup/security_group_in_rds_postgres.png" />

--- a/mint.json
+++ b/mint.json
@@ -70,7 +70,8 @@
         "peerdb-cloud/cloud-quickstart",
         "peerdb-cloud/cloud-security",
         "peerdb-cloud/peerdb-cloud-pricing-faq",
-        "peerdb-cloud/cloud-trust-center"
+        "peerdb-cloud/cloud-trust-center",
+        "peerdb-cloud/ip-table"
       ]
     },
     {
@@ -79,7 +80,7 @@
         "connect/snowflake",
         "connect/bigquery",
         {
-          "group": "Postgres",
+          "group": "PostgreSQL Setup Guide",
           "pages": [
             "connect/postgres/rds_postgres",
             "connect/postgres/cloudsql_postgres",

--- a/peerdb-cloud/ip-table.mdx
+++ b/peerdb-cloud/ip-table.mdx
@@ -1,0 +1,14 @@
+---
+title: "Public IPs For PeerDB Cloud"
+---
+
+Depending on the region you choose for your PeerDB Cloud instance, you will need to have the instance's public IPs be whitelisted in your peers.
+Below is a list of public IPs for each region:
+
+| Region | Public IPs |
+| --- | --- |
+| us-west-2 |`54.201.178.203, 100.21.65.249, 54.213.107.162`|
+| ap-south-1 | `3.109.74.175, 3.109.177.128, 13.201.199.0`|
+| ap-southeast-2 | `3.106.65.101, 54.66.63.23, 13.236.72.200`|
+| us-east-1 | `107.23.34.182, 52.5.156.236, 100.27.85.50`|
+| eu-central-1 | `35.159.188.24, 3.66.142.2, 18.185.234.115`|


### PR DESCRIPTION
Currently we say whitelist the IPs for us-west-2 but we have more regions now so the whitelisting is region dependent
Added a table with the region-ip mapping and adapted postgres setup docs to point to this