### PR TITLE
feat: Add AWS Private Link support to PeerDB Cloud documentation

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -71,7 +71,8 @@
         "peerdb-cloud/cloud-security",
         "peerdb-cloud/peerdb-cloud-pricing-faq",
         "peerdb-cloud/cloud-trust-center",
-        "peerdb-cloud/ip-table"
+        "peerdb-cloud/ip-table",
+        "peerdb-cloud/aws-private-link"
       ]
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "docs",
       "dependencies": {
         "mintlify": "^4.0.132"
       }
@@ -1386,11 +1387,11 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1971,9 +1972,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
-      "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -1984,7 +1985,7 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -2281,9 +2282,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -6048,12 +6049,12 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
-      "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "dependencies": {
         "debug": "~4.3.4",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       }
     },
     "node_modules/socket.io-parser": {
@@ -6793,15 +6794,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/peerdb-cloud/aws-private-link.mdx
+++ b/peerdb-cloud/aws-private-link.mdx
@@ -1,0 +1,31 @@
+---
+title: "AWS Private Link"
+icon: "diagram-project"
+iconType: "solid"
+---
+
+
+PeerDB Cloud supports AWS Private Link for secure and private connectivity between VPCs.
+This allows you to connect your VPCs to PeerDB Cloud without exposing your data to the public internet.
+
+## Setting up AWS Private Link with PeerDB Cloud
+
+<Steps>
+    <Step title="Setup Endpoint Service">
+        1. Create the necessary endpoint service as per preference. Some of the common ways to achieve this are (for Postgres):
+            - EC2 with script to fetch DNS records on schedule and update forwarding rules
+            - Lambda with listener to Event Bridge (CloudFormation Template available in [AWS Docs](https://aws.amazon.com/blogs/database/access-amazon-rds-across-vpcs-using-aws-privatelink-and-network-load-balancer/)
+        2. Give access to the PeerDB's AWS ARN `arn:aws:iam::141675317444:root` (or Account ID `141675317444`) so that it can be discovered for establishing the Private Link connection
+        3. (Optionally) Allow network connections from CIDR `10.0.0.0/16` to the Endpoint Service
+        4. Provide PeerDB Team with Endpoint Service Name (`com.amazonaws…`) and the region where the service is located
+           - This can be done either via contacting PeerDB Team via Slack or Email
+    </Step>
+    <Step title="PeerDB Team sets up Endpoint Interface">
+        1. PeerDB Team will setup the necessary Endpoint Interface
+        2. PeerDB Team will provide back the DNS name (for peer connectivity) and the Endpoint Interface ID for Accepting the Endpoint Interface request
+    </Step>
+    <Step title="Accept Endpoint Interface Request, Setup Peer">
+        1. Accept the Endpoint Interface Request
+        2. Create the peer via PeerDB UI (or ask PeerDB Team to perform a health check on the Endpoint Interface DNS from the same network as the PeerDB Cloud Instance)
+    </Step>
+</Steps>

--- a/peerdb-cloud/aws-private-link.mdx
+++ b/peerdb-cloud/aws-private-link.mdx
@@ -16,7 +16,7 @@ This allows you to connect your VPCs to PeerDB Cloud without exposing your data 
             - EC2 with script to fetch DNS records on schedule and update forwarding rules
             - Lambda with listener to Event Bridge (CloudFormation Template available in [AWS Docs](https://aws.amazon.com/blogs/database/access-amazon-rds-across-vpcs-using-aws-privatelink-and-network-load-balancer/)
         2. Give access to the PeerDB's AWS ARN `arn:aws:iam::141675317444:root` (or Account ID `141675317444`) so that it can be discovered for establishing the Private Link connection
-        3. (Optionally) Allow network connections from CIDR `10.0.0.0/16` to the Endpoint Service
+        3. (Optionally) Allow network connections from PeerDB's internal CIDR range `10.0.0.0/16` to the Endpoint Service
         4. Provide PeerDB Team with Endpoint Service Name (`com.amazonaws…`) and the region where the service is located
            - This can be done either via contacting PeerDB Team via Slack or Email
     </Step>

--- a/peerdb-cloud/ip-table.mdx
+++ b/peerdb-cloud/ip-table.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Public IPs For PeerDB Cloud"
+icon: "server"
+iconType: "regular"
 ---
 
 Depending on the region you choose for your PeerDB Cloud instance, you will need to have the instance's public IPs be whitelisted in your peers.


### PR DESCRIPTION
- Introduce a new page for AWS Private Link in the PeerDB Cloud documentation section
- Detail the setup process for AWS Private Link with PeerDB Cloud, including endpoint service setup, PeerDB team coordination, and peer setup


Generated:

<img width="1356" alt="image" src="https://github.com/PeerDB-io/docs/assets/39487888/f4d1f9a1-93a2-464d-9650-d349f4fc3122">

