### PR TITLE
Create peer doc: PG and CH

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -223,6 +223,7 @@
       "group": "API Endpoints",
       "pages": [
         "peerdb-api/reference",
+        "peerdb-api/endpoints/create-peer",
         "peerdb-api/endpoints/create-mirror",
         "peerdb-api/endpoints/custom-sync",
         "peerdb-api/endpoints/mirror-status",

--- a/peerdb-api/endpoints/create-peer.mdx
+++ b/peerdb-api/endpoints/create-peer.mdx
@@ -1,0 +1,287 @@
+
+```http
+POST api/v1/peers/create
+```
+
+This endpoint is used to create a peer. Peers represent data stores between which you can move data using a mirror.
+
+### Peers in this documentation:
+1. [Postgres peer](#postgres-peer)
+2. [Clickhouse peer](#clickhouse-peer)
+
+## Postgres Peer
+Here is the request and response format for creating a Postgres peer. SSH tunneling is optional for peer creation.
+
+### Request Fields
+<ParamField path="peer" type="object" required>
+Configuration of the peer to be created.
+</ParamField>
+
+<Expandable title="peer">
+<ParamField path="name" type="string" required>
+The name of the peer to be created.
+</ParamField>
+
+<ParamField path="type" type="3" required>
+The type of peer to be created. The value for Postgres is **3**.
+</ParamField>
+
+<ParamField path="postgres_config" type="object" required>
+Postgres config
+</ParamField>
+
+<Expandable title="postgres_config">
+<ParamField path="host" type="string" required>
+Host of the PG server.
+</ParamField>
+
+<ParamField path="port" type="number" required>
+Port on which the PG server is running. Ex: 5432
+</ParamField>
+
+<ParamField path="user" type="string" required>
+The user to connect to the PG server.
+</ParamField>
+
+<ParamField path="password" type="string" required>
+The password associated with the user.
+</ParamField>
+
+<ParamField path="database" type="string" required>
+The database to connect to.
+</ParamField>
+
+<ParamField path="ssh_config" type="object">
+Configuration for SSH tunneling
+</ParamField>
+
+<Expandable title="ssh_config">
+<ParamField path="host" type="string" required>
+The host of the SSH server.
+</ParamField>
+
+<ParamField path="port" type="number" required>
+The port on which the SSH server is running.
+</ParamField>
+
+<ParamField path="user" type="string" required>
+The user to connect to the SSH server.
+</ParamField>
+
+<ParamField path="password" type="string">
+The password associated with the user.
+</ParamField>
+
+<ParamField path="private_key" type="string" required>
+The private key as a string to connect to the SSH server.
+</ParamField>
+</Expandable>
+</Expandable>
+</Expandable>
+<ParamField path="allow_update" type="boolean">
+Whether you wish to update a peer with this name if it already exists. Default is `false`.
+</ParamField>
+
+### Response Fields
+<ParamField path="status" type="CREATED|FAILED">
+Whether the creation/update was successful. If yes, the value will be `CREATED`. Else it will be `FAILED`.
+</ParamField>
+
+<ParamField path="message" type="string">
+Error message if any
+</ParamField>
+
+<RequestExample>
+```bash Postgres peer
+curl --request POST \
+  --url http://localhost:3000/api/v1/peers/create \
+  --header 'Authorization: Basic OmJsYWNrU3dhbpEyMw==' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"peer": {
+		"name": "pg_peer_via_api",
+		"type": 3,
+		"postgres_config": {
+			"host": "localhost",
+			"port": 5432,
+			"user": "postgres",
+			"password": "postgres",
+			"database": "postgres"
+		}
+	},
+	"allow_update":false
+}'
+```
+
+```bash Clickhouse peer
+curl --request POST \
+  --url https//localhost:3000/api/v1/peers/create \
+  --header 'Authorization: Basic OmlsYWNrU3dhbjEyMw==' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"peer": {
+		"name": "ch_peer_via_api",
+		"type": 8,
+		"clickhouse_config": {
+			"host": "localhost",
+			"port": 9900,
+			"user": "default",
+			"password": "clickhouse",
+			"database": "clickhouse"
+		}
+	},
+	"allow_update":false
+}'
+```
+
+```bash Postgres peer with SSH tunneling
+curl --request POST \
+  --url http://localhost:3000/api/v1/peers/create \
+  --header 'Authorization: Basic OmJsYWNrU3dhbpEyMw==' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"peer": {
+		"name": "pg_peer_via_api",
+		"type": 3,
+		"postgres_config": {
+			"host": "localhost",
+			"port": 5432,
+			"user": "postgres",
+			"password": "postgres",
+			"database": "postgres",
+			"ssh_config": {
+				"host":"1.2.3.4",
+				"port":22,
+				"user":"ubuntu",
+				"private_key":"***"
+			}
+		}
+	}
+}'
+```
+</RequestExample>
+
+<ResponseExample>
+```json Success
+{
+	"status": "CREATED",
+	"message": ""
+}
+```
+
+```json Postgres error
+{
+	"status": "FAILED",
+	"message": "POSTGRES peer pg_peer_via_api was invalidated: failed to create ssh tunnel: no authentication methods provided"
+}
+```
+
+```json Clickhouse error
+{
+	"status": "FAILED",
+	"message": "CLICKHOUSE peer ch_peer_via_api was invalidated: failed to open connection to Clickhouse peer: failed to ping to Clickhouse peer: dial tcp [::1]:9900: connect: connection refused"
+}
+```
+</ResponseExample>
+
+## Clickhouse peer
+You can create a Clickhouse peer using this endpoint. Here is the request and response format for creating a Clickhouse peer.
+Note that the Clickhouse peer uses an intermediary S3 stage under the hood for performance. The S3 fields related to this are optional, because:
+- For PeerDB Cloud, the S3 bucket is managed by PeerDB
+- For PeerDB OSS, a minio bucket is provided as part of the stack.
+### Request Fields
+<ParamField path="peer" type="object" required>
+Configuration of the peer to be created.
+</ParamField>
+
+<Expandable title="peer">
+<ParamField path="name" type="string" required>
+The name of the peer to be created.
+</ParamField>
+
+<ParamField path="type" type="8" required>
+The type of peer to be created. The value for Clickhouse is **8**.
+</ParamField>
+
+<ParamField path="clickhouse_config" type="object" required>
+Clickhouse config
+</ParamField>
+
+<Expandable title="clickhouse_config">
+<ParamField path="host" type="string" required>
+Host of the Clickhouse server.
+</ParamField>
+
+<ParamField path="port" type="number" required>
+Port on which the Clickhouse server is running. Ex: 9440
+
+Make sure this is the **native TCP port**.
+</ParamField>
+
+<ParamField path="user" type="string" required>
+The user to connect to the Clickhouse server.
+</ParamField>
+
+<ParamField path="password" type="string" required>
+The password associated with the Clickhouse user.
+</ParamField>
+
+<ParamField path="database" type="string" required>
+The database to connect to.
+</ParamField>
+
+<ParamField path="disable_tls" type="boolean">
+Whether the Clickhouse server is running without TLS. Default is `false`.
+</ParamField>
+
+<ParamField path="certificate" type="string">
+Certificate to connect to the Clickhouse server.
+</ParamField>
+
+<ParamField path="private_key" type="string">
+Private key to connect to the Clickhouse server.
+</ParamField>
+
+<ParamField path="root_ca" type="string">
+Root CA to connect to the Clickhouse server.
+</ParamField>
+
+<ParamField path="s3_path" type="string">
+The S3 path to use for the stage. It is of the form `s3://bucket-name/path`.
+</ParamField>
+
+<ParamField path="access_key_id" type="string">
+The access key ID for the S3 bucket.
+</ParamField>
+
+<ParamField path="secret_access_key" type="string">
+The secret access key for the S3 bucket.
+</ParamField>
+
+<ParamField path="secret_access_key" type="string">
+The secret access key for the S3 bucket.
+</ParamField>
+
+<ParamField path="region" type="string">
+The region of the S3 bucket.
+</ParamField>
+
+<ParamField path="endpoint" type="string">
+The endpoint of the S3 bucket.
+</ParamField>
+
+</Expandable>
+</Expandable>
+<ParamField path="allow_update" type="boolean">
+Whether you wish to update a peer with this name if it already exists. Default is `false`.
+</ParamField>
+
+### Response Fields
+<ParamField path="status" type="CREATED|FAILED">
+Whether the creation/update was successful. If yes, the value will be `CREATED`. Else it will be `FAILED`.
+</ParamField>
+
+<ParamField path="message" type="string">
+Error message if any
+</ParamField>
+

--- a/peerdb-api/endpoints/create-peer.mdx
+++ b/peerdb-api/endpoints/create-peer.mdx
@@ -128,6 +128,29 @@ curl --request POST \
 			"user": "default",
 			"password": "clickhouse",
 			"database": "clickhouse",
+			"disable_tls": false
+		}
+	},
+	"allow_update":false
+}'
+```
+
+
+```bash Clickhouse peer with cert auth
+curl --request POST \
+  --url https://ui-lfvomdsjuoecprfp.instances.prod-cloud-1.us-west-2.aws.peerdb.cloud/api/v1/peers/create \
+  --header 'Authorization: Basic OmJsYPNrU3dhbjEyMw==' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"peer": {
+		"name": "ch_peer_via_api",
+		"type": 8,
+		"clickhouse_config": {
+			"host": "localhost",
+			"port": 9900,
+			"user": "default",
+			"password": "clickhouse",
+			"database": "clickhouse",
 			"disable_tls": false,
 			"certificate":"",
 			"private_key":"***",

--- a/peerdb-api/endpoints/create-peer.mdx
+++ b/peerdb-api/endpoints/create-peer.mdx
@@ -115,8 +115,8 @@ curl --request POST \
 
 ```bash Clickhouse peer
 curl --request POST \
-  --url https//localhost:3000/api/v1/peers/create \
-  --header 'Authorization: Basic OmlsYWNrU3dhbjEyMw==' \
+  --url https://ui-lfvomdsjuoecprfp.instances.prod-cloud-1.us-west-2.aws.peerdb.cloud/api/v1/peers/create \
+  --header 'Authorization: Basic OmJsYPNrU3dhbjEyMw==' \
   --header 'Content-Type: application/json' \
   --data '{
 	"peer": {
@@ -127,7 +127,11 @@ curl --request POST \
 			"port": 9900,
 			"user": "default",
 			"password": "clickhouse",
-			"database": "clickhouse"
+			"database": "clickhouse",
+			"disable_tls": false,
+			"certificate":"",
+			"private_key":"***",
+			"root_ca":""
 		}
 	},
 	"allow_update":false

--- a/peerdb-api/endpoints/create-peer.mdx
+++ b/peerdb-api/endpoints/create-peer.mdx
@@ -208,7 +208,7 @@ The type of peer to be created. The value for Clickhouse is **8**.
 </ParamField>
 
 <ParamField path="clickhouse_config" type="object" required>
-Clickhouse config
+Configuration for the Clickhouse peer
 </ParamField>
 
 <Expandable title="clickhouse_config">


### PR DESCRIPTION
Create peer documentation for Postgres and Clickhouse. Postgres includes SSH Tunneling. CH includes S3 fields and certificate, private key and root CA