### PR TITLE
Dont recommend for all tables publications

### DIFF
--- a/connect/postgres/azure_flexible_server_postgres.mdx
+++ b/connect/postgres/azure_flexible_server_postgres.mdx
@@ -65,10 +65,10 @@ Connect to your Azure Flexible Server Postgrees through the admin user and run t
            ALTER ROLE peerdb_user REPLICATION;
         ```
 
-4. Create publication that you'll be using for creating the MIRROR (replication) in future.
+4. Create a publication that you'll be using for creating the MIRROR (replication) in future.
 
     1. ```sql
-              CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
+          CREATE PUBLICATION peerdb_publication FOR TABLE table1, table2, table3....;
         ```
 
 5. Set `wal_sender_timeout` to 0 for `peerdb_user`

--- a/connect/postgres/cloudsql_postgres.mdx
+++ b/connect/postgres/cloudsql_postgres.mdx
@@ -84,10 +84,10 @@ Connect to your CloudSQL Postgres through the admin user and run the below comma
            ALTER ROLE peerdb_user REPLICATION;
         ```
 
-4. Create publication that you'll be using for creating the MIRROR (replication) in future.
+4. Create a publication that you'll be using for creating the MIRROR (replication) in future.
 
     1. ```sql
-              CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
+          CREATE PUBLICATION peerdb_publication FOR TABLE table1, table2, table3....;
         ```
 
 <SSHTunnel />

--- a/connect/postgres/crunchy_bridge.mdx
+++ b/connect/postgres/crunchy_bridge.mdx
@@ -36,10 +36,10 @@ Connect to your Crunchy Bridge Postgres through the `postgres` user and run the 
          ALTER ROLE peerdb_user REPLICATION;
         ```
 
-4. Create publication that you'll be using for creating the MIRROR (replication) in future.
+4. Create a publication that you'll be using for creating the MIRROR (replication) in future.
 
     1. ```sql
-          CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
+          CREATE PUBLICATION peerdb_publication FOR TABLE table1, table2, table3....;
         ```
 
 <SSHTunnel />

--- a/connect/postgres/neon_postgres.mdx
+++ b/connect/postgres/neon_postgres.mdx
@@ -21,8 +21,9 @@ Here, we can run the following SQL commands:
 -- Give replication permission to the USER
   ALTER USER peerdb_user REPLICATION;
 
--- Create a publication. We will use this when creating the mirror
-  CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
+-- Create a publication with the tables you wish to replicate. We will use this when creating the mirror
+  CREATE PUBLICATION peerdb_publication FOR TABLE table1, table2, table3....;
+
 ```
 
 <Frame caption="User and publication commands">

--- a/connect/postgres/rds_postgres.mdx
+++ b/connect/postgres/rds_postgres.mdx
@@ -67,7 +67,7 @@ Connect to your RDS postgres through the admin user and run the below commands:
           GRANT rds_replication TO peerdb_user ;
         ```
 
-4. Create publication that you'll be using for creating the MIRROR (replication) in future.
+4. Create a publication that you'll be using for creating the MIRROR (replication) in future.
 It's recommended to create a publication for only the tables that you want to replicate, like below:
 
     1. ```sql

--- a/connect/postgres/rds_postgres.mdx
+++ b/connect/postgres/rds_postgres.mdx
@@ -68,9 +68,10 @@ Connect to your RDS postgres through the admin user and run the below commands:
         ```
 
 4. Create publication that you'll be using for creating the MIRROR (replication) in future.
+It's recommended to create a publication for only the tables that you want to replicate, like below:
 
     1. ```sql
-          CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
+          CREATE PUBLICATION peerdb_publication FOR TABLE table1, table2, table3....;
         ```
 
 <SSHTunnel />

--- a/connect/postgres/supabase_postgres.mdx
+++ b/connect/postgres/supabase_postgres.mdx
@@ -25,8 +25,9 @@ Here, we can run the following SQL commands:
 -- Give replication permission to the USER
   ALTER USER peerdb_user REPLICATION;
 
--- Create a publication. We will use this when creating the mirror
-  CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
+-- Create a publication with the tables you wish to replicate. We will use this when creating the mirror
+  CREATE PUBLICATION peerdb_publication FOR TABLE table1, table2, table3....;
+
 ```
 
 <Frame caption="User and publication commands">

--- a/connect/postgres/supabase_postgres_peerdb_cloud.mdx
+++ b/connect/postgres/supabase_postgres_peerdb_cloud.mdx
@@ -23,8 +23,9 @@ Here, we can run the following SQL commands:
 -- Give replication permission to the USER
   ALTER USER peerdb_user REPLICATION;
 
--- Create a publication. We will use this when creating the mirror
-  CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
+-- Create a publication with the tables you wish to replicate. We will use this when creating the mirror
+  CREATE PUBLICATION peerdb_publication FOR TABLE table1, table2, table3....;
+
 ```
 
 <Frame caption="User and publication commands">


### PR DESCRIPTION
This doc changes the recommendation in our Postgres setup docs from FOR ALL TABLES in publications to FOR TABLE table1, table2, table3... 