### PR TITLE
API create peer overview: fix peer links

### DIFF
--- a/peerdb-api/endpoints/create-peer/overview.mdx
+++ b/peerdb-api/endpoints/create-peer/overview.mdx
@@ -5,6 +5,6 @@ POST api/v1/peers/create
 This endpoint is used to create a peer. Peers represent data stores between which you can move data using a mirror.
 
 ### Peers in this documentation:
-1. [Postgres peer](/postgres)
-2. [Clickhouse peer](/clickhouse)
-3. [Kafka peer](/kafka)
+1. [Postgres peer](/peerdb-api/endpoints/create-peer/postgres)
+2. [Clickhouse peer](/peerdb-api/endpoints/create-peer/clickhouse)
+3. [Kafka peer](/peerdb-api/endpoints/create-peer/kafka)


### PR DESCRIPTION
Fix the quick links in overview page of create peer api 