### PR TITLE
Add note on RLS for Postgres guides

### DIFF
--- a/connect/postgres/azure_flexible_server_postgres.mdx
+++ b/connect/postgres/azure_flexible_server_postgres.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Azure Flexible Server Postgres Source Setup Guide"
 ---
-
+import RLSNote from '/snippets/rls-note.mdx';
 import SSHTunnel from '/snippets/ssh-tunnel.mdx';
 
 ## Supported Postgres versions
@@ -65,6 +65,8 @@ Connect to your Azure Flexible Server Postgres through the admin user and run th
 ```sql
         ALTER ROLE peerdb_user SET wal_sender_timeout to 0;
 ```
+
+<RLSNote />
 
 <SSHTunnel />
 

--- a/connect/postgres/cloudsql_postgres.mdx
+++ b/connect/postgres/cloudsql_postgres.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Google CloudSQL Postgres Source Setup Guide"
 ---
-
+import RLSNote from '/snippets/rls-note.mdx';
 import SSHTunnel from '/snippets/ssh-tunnel.mdx';
 
 ## Supported Postgres versions
@@ -62,6 +62,7 @@ Connect to your CloudSQL Postgres through the admin user and run the below comma
     1. ```sql
               CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
         ```
+<RLSNote />
 
 <SSHTunnel />
 

--- a/connect/postgres/crunchy_bridge.mdx
+++ b/connect/postgres/crunchy_bridge.mdx
@@ -2,6 +2,8 @@
 title: "Crunchy Bridge Postgres Source Setup Guide"
 ---
 
+import RLSNote from '/snippets/rls-note.mdx';
+
 ## Enable Logical Replication
 
 Crunchy Bridge comes with logical replication enabled by [default](https://docs.crunchybridge.com/how-to/logical-replication). Ensure that the settings below are configured correctly. If not, adjust them accordingly.
@@ -41,6 +43,8 @@ Connect to your Crunchy Bridge Postgres through the `postgres` user and run the 
     1. ```sql
           CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
         ```
+
+<RLSNote />
 
 <SSHTunnel />
 

--- a/connect/postgres/generic_postgres.mdx
+++ b/connect/postgres/generic_postgres.mdx
@@ -2,6 +2,8 @@
 title: "Generic PostgreSQL Source Setup Guide"
 ---
 
+import RLSNote from '/snippets/rls-note.mdx';
+
 This is a guide on how to create a generic PostgreSQL peer which you can use for replication in PeerDB.
 
 <Info>
@@ -52,6 +54,8 @@ If you use one of the supported providers (in the sidebar), please refer to the 
 
 Let's create a new user for PeerDB with the necessary permissions suitable for CDC,
 and also create a publication that we'll use for replication.
+
+<RLSNote />
 
 For this, you can connect to your PostgreSQL instance and run the following SQL commands:
 ```sql

--- a/connect/postgres/neon_postgres.mdx
+++ b/connect/postgres/neon_postgres.mdx
@@ -2,6 +2,8 @@
 title: "Neon Postgres Source Setup Guide"
 ---
 
+import RLSNote from '/snippets/rls-note.mdx';
+
 This is a guide on how to create a Neon PostgreSQL peer which you can use for replication in PeerDB.
 Make sure you're signed in to your [Neon console](https://console.neon.tech/app/projects) for this setup.
 
@@ -28,6 +30,8 @@ Here, we can run the following SQL commands:
 <Frame caption="User and publication commands">
 <img src="/images/neon-setup/neon-commands.png" />
 </Frame>
+
+<RLSNote />
 
 Click on **Run** to have a publication and a user ready.
 

--- a/connect/postgres/rds_postgres.mdx
+++ b/connect/postgres/rds_postgres.mdx
@@ -3,6 +3,7 @@ title: "RDS Postgres Source Setup Guide"
 ---
 
 import SSHTunnel from '/snippets/ssh-tunnel.mdx';
+import RLSNote from '/snippets/rls-note.mdx';
 
 ## Supported Postgres versions
 
@@ -72,6 +73,8 @@ Connect to your RDS postgres through the admin user and run the below commands:
     1. ```sql
           CREATE PUBLICATION peerdb_publication FOR ALL TABLES;
         ```
+
+<RLSNote />
 
 <SSHTunnel />
 

--- a/connect/postgres/supabase_postgres.mdx
+++ b/connect/postgres/supabase_postgres.mdx
@@ -2,6 +2,7 @@
 title: "Supabase Postgres Source Setup Guide"
 ---
 import RLSNote from '/snippets/rls-note.mdx';
+
 This is a guide on how to create a Supabase PostgreSQL peer which you can use for replication in PeerDB.
 <Note>
 PeerDB Cloud supports Supabase via IPv6 natively for seemless replication.

--- a/connect/postgres/supabase_postgres.mdx
+++ b/connect/postgres/supabase_postgres.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Supabase Postgres Source Setup Guide"
 ---
-
+import RLSNote from '/snippets/rls-note.mdx';
 This is a guide on how to create a Supabase PostgreSQL peer which you can use for replication in PeerDB.
 <Note>
 PeerDB Cloud supports Supabase via IPv6 natively for seemless replication.
@@ -34,6 +34,8 @@ Here, we can run the following SQL commands:
 </Frame>
 
 Click on **Run** to have a publication and a user ready.
+
+<RLSNote />
 <Note>
 Make sure to replace `peerdb_user` and `peerdb_password` with your desired username and password.
 

--- a/connect/postgres/supabase_postgres_peerdb_cloud.mdx
+++ b/connect/postgres/supabase_postgres_peerdb_cloud.mdx
@@ -2,6 +2,8 @@
 title: "Supabase Postgres Source Setup Guide on PeerDB Cloud"
 ---
 
+import RLSNote from '/snippets/rls-note.mdx';
+
 This is a guide on how to create a supabase PostgreSQL peer which you can use for replication in PeerDB.
 <Check>
 PeerDB Cloud supports Supabase via IPv6 natively for seemless replication.
@@ -34,6 +36,7 @@ Here, we can run the following SQL commands:
 </Frame>
 
 Click on **Run** to have a publication and a user ready.
+
 <Note>
 Make sure to replace `peerdb_user` and `peerdb_password` with your desired username and password.
 
@@ -77,7 +80,7 @@ Fill in the username and password you created earlier in the SQL Editor in Step 
 </Frame>
 
 5. Click on **Validate** and once that's green, you can go ahead and click on **Create** to create the peer!
-
+<RLSNote />
 
 </Step>
 <Step title='Increase max_slot_wal_keep_size'>

--- a/snippets/rls-note.mdx
+++ b/snippets/rls-note.mdx
@@ -1,0 +1,7 @@
+<Note>
+For initial load of the tables, the user must not be restricted by RLS policies. You can disable RLS policies for the user by running the below command:
+
+```sql
+ALTER USER peerdb_user BYPASSRLS;
+```
+</Note>

--- a/snippets/rls-note.mdx
+++ b/snippets/rls-note.mdx
@@ -1,5 +1,5 @@
 <Note>
-For initial load of the tables, the user must not be restricted by RLS policies. You can disable RLS policies for the user by running the below command:
+The PeerDB user must not be restricted by RLS policies, as it can lead to missing data. You can disable RLS policies for the user by running the below command:
 
 ```sql
 ALTER USER peerdb_user BYPASSRLS;

--- a/snippets/ssh-tunnel.mdx
+++ b/snippets/ssh-tunnel.mdx
@@ -10,7 +10,7 @@ of this is handled by PeerDB natively.
 <Steps>
     <Step title="Generate a key-pair">
         Generate a key-pair using the following command:
-        
+
         ```bash
         ssh-keygen -t rsa -b 4096 -C "peerdb-ssh-tunnel" -f peerdb_key.pem
         ```


### PR DESCRIPTION
This PR adds a note on modifying RLS to not hinder initial loads of mirrors. This note is added to all Postgres guide docs

![Screenshot 2025-01-10 at 12 53 10 AM](https://github.com/user-attachments/assets/00de8589-d790-4a80-a84c-4a43f6ffd4ac)
