### PR TITLE
Mention column added only after update of the table

### DIFF
--- a/features/schema-changes.mdx
+++ b/features/schema-changes.mdx
@@ -6,6 +6,6 @@ PeerDB's Postgres connector can detect schema changes in the source tables. For 
 
 | Schema Change Type                                                                  | Behaviour                             |
 | ----------------------------------------------------------------------------------- | ------------------------------------- |
-| Adding a new column (`ALTER TABLE ADD COLUMN ...`)                                  | Propagated automatically, all rows after the change will have all columns filled                                                                         |
-| Adding a new column with a default value (`ALTER TABLE ADD COLUMN ... DEFAULT ...`) | Propagated automatically, all rows after the change will have all columns filled but existing rows will not show the DEFAULT value without a full table refresh |
+| Adding a new column (`ALTER TABLE ADD COLUMN ...`)                                  | Propagated automatically once the table gets an insert/update/delete, all rows after the change will have all columns filled                                                                         |
+| Adding a new column with a default value (`ALTER TABLE ADD COLUMN ... DEFAULT ...`) | Propagated automatically once the table gets an insert/update/delete, all rows after the change will have all columns filled but existing rows will not show the DEFAULT value without a full table refresh |
 | Dropping an existing column (`ALTER TABLE DROP COLUMN ...`)                         | Detected, but not propagated. All rows after the change will have NULL for the dropped columns                                                                |


### PR DESCRIPTION
Documents that PeerDB replicates column addition only after the table gets an update