### PR TITLE
Deprecate non-ClickHouse/non-Postgres destinations and QRep/XMIN mirror types

### DIFF
--- a/connect/bigquery.mdx
+++ b/connect/bigquery.mdx
@@ -2,6 +2,10 @@
 title: "BigQuery Setup Guide"
 ---
 
+<Warning>
+BigQuery as a **destination** is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination. Note that BigQuery remains a **supported source**.
+</Warning>
+
 1. [Create a dedicated Service Account](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console) for PeerDB through Google Cloud Console and specify `BigQuery Data Editor`, `BigQuery Data Viewer`, `BigQuery Job User`, `BigQuery Resource Viewer`
 
    <Frame caption="Create a dedicated Service Account For PeerDB and grant the necessary permissions">

--- a/connect/confluent-cloud.mdx
+++ b/connect/confluent-cloud.mdx
@@ -2,6 +2,10 @@
 title: "Confluent Cloud Setup Guide"
 ---
 
+<Warning>
+Kafka as a destination (including the Confluent and Redpanda variants) is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 # Prerequisites
 
 To connect Confluent Cloud to PeerDB, you need a Confluent Cloud account with Kafka Server running.

--- a/connect/elasticsearch.mdx
+++ b/connect/elasticsearch.mdx
@@ -2,6 +2,10 @@
 title: "Elasticsearch Setup Guide"
 ---
 
+<Warning>
+Elasticsearch as a destination is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 # Prerequisites
 PeerDB can authenticate with Elasticsearch via either basic auth or an API key, or no auth at all. In general, Elasticsearch Cloud authenticates via API keys and self-hosted Elasticsearch can vary. If applicable, atleast the following privileges need to be granted to the PeerDB role: `auto_configure`, `create_doc`, `write`.
 

--- a/connect/gcs.mdx
+++ b/connect/gcs.mdx
@@ -2,6 +2,10 @@
 title: "GCS Setup Guide"
 ---
 
+<Warning>
+GCS (a Google Cloud Storage destination) is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 1. Create a new Cloud Storage bucket or ensure an existing bucket is available for use.
 2. We need to create an access key pair, for connecting to this bucket. This access key can be on a user account or on a service account. We recommend [creating](https://cloud.google.com/iam/docs/service-accounts-create) a dedicated service account for PeerDB, with the `Storage Object User` role. After this, [create a HMAC key-pair](https://cloud.google.com/storage/docs/authentication/managing-hmackeys) for the service account.
 <Frame caption="Creating SA for PeerDB">

--- a/connect/kafka.mdx
+++ b/connect/kafka.mdx
@@ -2,6 +2,10 @@
 title: "Kafka Setup Guide"
 ---
 
+<Warning>
+Kafka as a destination (including the Confluent and Redpanda variants) is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 If looking to try out without an already setup Kafka endpoint, [see Redpanda quickstart,](https://docs.redpanda.com/current/get-started/quick-start) by default no authentication is necessary.
 
 To get the above redpanda container to work with PeerDB on OSS, you can first add it to the PeerDB containers' network:

--- a/connect/pubsub.mdx
+++ b/connect/pubsub.mdx
@@ -2,6 +2,10 @@
 title: "PubSub Setup Guide"
 ---
 
+<Warning>
+Google Pub/Sub as a destination is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 1. [Create a dedicated Service Account](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console) 
 for PeerDB through Google Cloud Console and specify the following roles:
 - `Pub/Sub Viewer` : PeerDB requires this role to check if your provided topic exists.

--- a/connect/s3.mdx
+++ b/connect/s3.mdx
@@ -2,6 +2,10 @@
 title: "S3 Setup Guide"
 ---
 
+<Warning>
+S3 as a destination is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 1. Create an S3 bucket or ensure an existing bucket is available for use.
 2. For PeerDB to access the S3 Peer, you can either use an existing AWS user or create a new AWS user.
 3. Create access keys for that user through [AWS Console](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey) or [AWS CLI](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey_CLIAPI) or [AWS API](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey_API). By the end, you should have an access key along with its secret.

--- a/connect/snowflake.mdx
+++ b/connect/snowflake.mdx
@@ -2,6 +2,10 @@
 title: "Snowflake Setup Guide"
 ---
 
+<Warning>
+Snowflake as a destination is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 ## Prerequisites
 
 To connect Snowflake to PeerDB, you need a Snowflake account with the appropriate permissions to create a user and warehouse for PeerDB.

--- a/features/feature-matrix.mdx
+++ b/features/feature-matrix.mdx
@@ -1,3 +1,9 @@
+<Warning>
+The actively-maintained destinations are **ClickHouse**, **ClickHouse Cloud**, and **Postgres**. Snowflake, ElasticSearch, Kafka (including the Confluent and Redpanda variants), Azure Event Hubs, Google Pub/Sub, S3, GCS, and BigQuery as a destination are deprecated and no longer actively maintained. They remain fully functional and no code is currently being removed. BigQuery is deprecated **only as a destination**; it remains a **supported source**.
+
+Query Based or Watermark Based Replication (QRep), including XMIN-based replication, is also a deprecated mirror type. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors.
+</Warning>
+
 # WAL or Change Data Capture (CDC) Based Replication
 
 Below table shows supported features and features we are working on for WAL or CDC Based replication from **Postgres** to different targets.
@@ -33,6 +39,10 @@ Below table shows supported features and features we are working on for WAL or C
 | Resync Mirrors | 🛠️ | N/A | N/A | N/A |
 | Column Exclusion | ✅ | ✅ | ✅ | ✅ |
 # Query Based or Watermark Based Replication
+
+<Warning>
+Query Based or Watermark Based Replication (QRep), including XMIN-based replication, is a deprecated mirror type and no longer actively maintained. It remains fully functional and no code is currently being removed. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors.
+</Warning>
 
 Below table shows supported features and features we are working on for Query Based or Watermark Based Replication from **Postgres** to different targets.
 ✅ means supported. 🛠️ means **Work in Progress and Coming Soon!**.

--- a/features/supported-connectors.mdx
+++ b/features/supported-connectors.mdx
@@ -1,27 +1,33 @@
 
+<Warning>
+The actively-maintained destinations are **ClickHouse**, **ClickHouse Cloud**, and **Postgres**. The destinations marked _(deprecated)_ below (Snowflake, ElasticSearch, Kafka including the Confluent and Redpanda variants, Azure Event Hubs, Google Pub/Sub, S3, GCS, and BigQuery) are deprecated and no longer actively maintained. They remain fully functional and no code is currently being removed. BigQuery is deprecated **only as a destination**; it remains a **supported source**.
+
+Streaming Query Replication (QRep), including XMIN-based replication, is also a deprecated mirror type. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors.
+</Warning>
+
 Below table shows supported source and target connectors for [Real-time Change Data Capture](/usecases/real-time-cdc/overview) and [Streaming Query Replication](/usecases/streaming-query-replication/overview). ✅ means supported. ⚠️  means beta. 🛑 means unsupported. **N/A** means Not Applicable
 | Source       | Target          | Real-time Change Data Capture (CDC) | Streaming Query or Watermark Based Replication | Guides |
 |--------------|-----------------|---------------|----------------------------|----------------------------|
-| PostgreSQL   | Snowflake       |       ✅       |            ✅              |[Change Data Capture](/mirror/cdc-pg-sf),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-snowflake)|
-| PostgreSQL   | BigQuery        |       ✅       |            ✅              |[Change Data Capture](/mirror/cdc-pg-bq),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-bigquery)|
+| PostgreSQL   | Snowflake _(deprecated)_      |       ✅       |            ✅              |[Change Data Capture](/mirror/cdc-pg-sf),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-snowflake)|
+| PostgreSQL   | BigQuery _(deprecated as destination)_       |       ✅       |            ✅              |[Change Data Capture](/mirror/cdc-pg-bq),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-bigquery)|
 | PostgreSQL   | PostgreSQL     |       ✅       |            ✅              |[Change Data Capture](/mirror/cdc-pg-pg),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-postgres)|
 | PostgreSQL   | ClickHouse          |      ✅      |            ✅             | [Change Data Capture](/mirror/cdc-pg-clickhouse) |
-| PostgreSQL   | Kafka          |      ✅      |            N/A             | [Setup Kafka Peer](/connect/kafka) |
-| PostgreSQL   | Redpanda          |      ✅      |            N/A             | [Setup Redpanda Peer](/connect/kafka) |
-| PostgreSQL   | Google PubSub          |     ✅       |            N/A             | [Setup PubSub Peer](/connect/pubsub) |
-| PostgreSQL   | Azure EventHubs |      ✅      |            N/A             |[Change Data Capture](/usecases/real-time-cdc/postgres-to-azure-eventhubs)|
-| PostgreSQL   | S3              |       ✅       |            ✅              |[Change Data Capture](/usecases/real-time-cdc/postgres-to-cloud),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-s3)|
-| PostgreSQL   | GCS              |       ✅       |            ✅              |[Change Data Capture](/usecases/real-time-cdc/postgres-to-cloud),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-s3)|
-| MySQL        | Snowflake       |       ✅       |            ✅              | |
-| MySQL        | BigQuery        |       ✅       |            ✅              | |
+| PostgreSQL   | Kafka _(deprecated)_         |      ✅      |            N/A             | [Setup Kafka Peer](/connect/kafka) |
+| PostgreSQL   | Redpanda _(deprecated)_         |      ✅      |            N/A             | [Setup Redpanda Peer](/connect/kafka) |
+| PostgreSQL   | Google PubSub _(deprecated)_         |     ✅       |            N/A             | [Setup PubSub Peer](/connect/pubsub) |
+| PostgreSQL   | Azure EventHubs _(deprecated)_ |      ✅      |            N/A             |[Change Data Capture](/usecases/real-time-cdc/postgres-to-azure-eventhubs)|
+| PostgreSQL   | S3 _(deprecated)_             |       ✅       |            ✅              |[Change Data Capture](/usecases/real-time-cdc/postgres-to-cloud),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-s3)|
+| PostgreSQL   | GCS _(deprecated)_             |       ✅       |            ✅              |[Change Data Capture](/usecases/real-time-cdc/postgres-to-cloud),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-s3)|
+| MySQL        | Snowflake _(deprecated)_      |       ✅       |            ✅              | |
+| MySQL        | BigQuery _(deprecated as destination)_       |       ✅       |            ✅              | |
 | MySQL        | PostgreSQL      |       ✅       |            ✅              | |
 | MySQL        | ClickHouse      |       ✅       |            ✅              | |
-| MySQL        | Kafka           |       ✅       |            N/A             | |
-| MySQL        | Redpanda        |       ✅       |            N/A             | |
-| MySQL        | Google PubSub   |       ✅       |            N/A             | |
-| MySQL        | Azure EventHubs |       ✅       |            N/A             | |
-| MySQL        | S3              |       ✅       |            ✅              | |
-| MySQL        | GCS             |       ✅       |            ✅              | |
+| MySQL        | Kafka _(deprecated)_          |       ✅       |            N/A             | |
+| MySQL        | Redpanda _(deprecated)_       |       ✅       |            N/A             | |
+| MySQL        | Google PubSub _(deprecated)_  |       ✅       |            N/A             | |
+| MySQL        | Azure EventHubs _(deprecated)_ |       ✅       |            N/A             | |
+| MySQL        | S3 _(deprecated)_             |       ✅       |            ✅              | |
+| MySQL        | GCS _(deprecated)_            |       ✅       |            ✅              | |
 | MongoDB      | ClickHouse      |       ✅       |            ✅              | |
 
 We are actively adding more sources and targets. If you need any specific connector as a source or target to your PostgreSQL database reach out to us at contact@peerdb.io

--- a/mirror/cdc-pg-bq.mdx
+++ b/mirror/cdc-pg-bq.mdx
@@ -2,6 +2,9 @@
 title: "CDC Setup from Postgres to Bigquery"
 ---
 
+<Warning>
+BigQuery as a **destination** is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination. Note that BigQuery remains a **supported source**.
+</Warning>
 
 ## Prerequisites
 

--- a/mirror/cdc-pg-elasticsearch.mdx
+++ b/mirror/cdc-pg-elasticsearch.mdx
@@ -2,6 +2,9 @@
 title: "CDC Setup from Postgres to Elasticsearch"
 ---
 
+<Warning>
+Elasticsearch as a destination is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
 
 ## Prerequisites
 

--- a/mirror/cdc-pg-kafka.mdx
+++ b/mirror/cdc-pg-kafka.mdx
@@ -2,6 +2,9 @@
 title: "CDC Setup from Postgres to Kafka"
 ---
 
+<Warning>
+Kafka as a destination (including the Confluent and Redpanda variants) is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
 
 ## Prerequisites
 

--- a/mirror/cdc-pg-sf.mdx
+++ b/mirror/cdc-pg-sf.mdx
@@ -2,6 +2,9 @@
 title: "CDC Setup from Postgres to Snowflake"
 ---
 
+<Warning>
+Snowflake as a destination is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
 
 ## Prerequisites
 

--- a/sql/commands/create-mirror.mdx
+++ b/sql/commands/create-mirror.mdx
@@ -59,6 +59,10 @@ This is optional as PeerDB creates the slot it needs by default. A use-case for 
 
 ### MIRROR for Streaming Query Results
 
+<Warning>
+Streaming Query Replication (QRep), including XMIN-based replication, is a deprecated mirror type and no longer actively maintained. It remains fully functional and no code is currently being removed. We recommend the **MIRROR for CDC** type above as the actively-maintained mirror type for new mirrors.
+</Warning>
+
 This type of MIRROR periodically streams query results on the source peer to the target peer.
 
 ```sql
@@ -100,6 +104,11 @@ The `OPTIONS` clause provides granular control when configuring the MIRROR:
 7. `if_not_exists`: If specified, the MIRROR will be created only if it does not exist.
 
 #### XMIN Query Replication
+
+<Warning>
+XMIN Query Replication is a deprecated mirror type and no longer actively maintained. It remains fully functional and no code is currently being removed. We recommend the **MIRROR for CDC** type as the actively-maintained mirror type for new mirrors.
+</Warning>
+
 PeerDB supports `xmin` as watermark column. Note that DELETEs are not supported in XMIN Query Replication.
 
 ```sql

--- a/sql/commands/supported-connectors.mdx
+++ b/sql/commands/supported-connectors.mdx
@@ -1,15 +1,21 @@
 
+<Warning>
+The actively-maintained destinations are **ClickHouse**, **ClickHouse Cloud**, and **Postgres**. The destinations marked _(deprecated)_ below (Snowflake, ElasticSearch, Kafka including the Confluent and Redpanda variants, Azure Event Hubs, Google Pub/Sub, S3, GCS, and BigQuery) are deprecated and no longer actively maintained. They remain fully functional and no code is currently being removed. BigQuery is deprecated **only as a destination**; it remains a **supported source**.
+
+Streaming Query Replication (QRep), including XMIN-based replication, is also a deprecated mirror type. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors.
+</Warning>
+
 Below table shows supported source and target connectors for [Real-time Change Data Capture](/usecases/real-time-cdc/overview) and [Streaming Query Replication](/usecases/streaming-query-replication/overview). ✅ means supported. ⚠️  means beta. 🛑 means unsupported
 | Source       | Target          | Real-time Change Data Capture (CDC) | Streaming Query or Watermark Based Replication | Guides |
 |--------------|-----------------|---------------|----------------------------|----------------------------|
-| PostgreSQL   | Snowflake       |       ✅       |            ✅              |[CDC](/usecases/real-time-cdc/postgres-to-snowflake),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-snowflake)|
-| PostgreSQL   | BigQuery        |       ✅       |            ✅              |[CDC](/usecases/real-time-cdc/postgres-to-bigquery),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-bigquery)|
+| PostgreSQL   | Snowflake _(deprecated)_       |       ✅       |            ✅              |[CDC](/usecases/real-time-cdc/postgres-to-snowflake),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-snowflake)|
+| PostgreSQL   | BigQuery _(deprecated as destination)_        |       ✅       |            ✅              |[CDC](/usecases/real-time-cdc/postgres-to-bigquery),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-bigquery)|
 | PostgreSQL   | PostgreSQL     |       ✅       |            ✅              |[CDC](/usecases/real-time-cdc/postgres-to-postgres),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-postgres)|
 | PostgreSQL   | Clickhouse          |      ✅      |            ✅             | https://docs.peerdb.io/mirror/cdc-pg-clickhouse |
-| PostgreSQL   | S3              |       ✅       |            ✅              |[CDC](/usecases/real-time-cdc/postgres-to-cloud),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-s3)|
-| PostgreSQL   | GCS              |       ✅       |            ✅              |[CDC](/usecases/real-time-cdc/postgres-to-cloud),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-s3)|
-| PostgreSQL   | Azure EventHubs |      ✅      |            🛑             |[CDC](/usecases/real-time-cdc/postgres-to-azure-eventhubs)|
-| PostgreSQL   | Kafka          |      ⚠️      |            🛑             | Coming soon ! |
-| PostgreSQL   | Google PubSub          |     ⚠️       |            ⚠️             | Coming soon ! |
+| PostgreSQL   | S3 _(deprecated)_              |       ✅       |            ✅              |[CDC](/usecases/real-time-cdc/postgres-to-cloud),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-s3)|
+| PostgreSQL   | GCS _(deprecated)_              |       ✅       |            ✅              |[CDC](/usecases/real-time-cdc/postgres-to-cloud),[Streaming Query Replication](/usecases/streaming-query-replication/postgres-to-s3)|
+| PostgreSQL   | Azure EventHubs _(deprecated)_ |      ✅      |            🛑             |[CDC](/usecases/real-time-cdc/postgres-to-azure-eventhubs)|
+| PostgreSQL   | Kafka _(deprecated)_         |      ⚠️      |            🛑             | Coming soon ! |
+| PostgreSQL   | Google PubSub _(deprecated)_         |     ⚠️       |            ⚠️             | Coming soon ! |
 
 We are actively adding more sources and targets. If you need any specific connector as a source or target to your PostgreSQL database reach out to us at contact@peerdb.io

--- a/tutorials/realtime-streaming-of-query-results.mdx
+++ b/tutorials/realtime-streaming-of-query-results.mdx
@@ -2,6 +2,10 @@
 title: "Streaming Query Replication of PostgreSQL To Snowflake"
 ---
 
+<Warning>
+Streaming Query Replication (QRep) is a deprecated mirror type and no longer actively maintained. It remains fully functional and no code is currently being removed. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors. Snowflake as a destination is also deprecated.
+</Warning>
+
 Below is a 5-minute tutorial to test [Streaming Query Replication from Postgres to Snowflake](/usecases/realtime-streaming-of-query-results)
 
 ### Step 1: CREATE Postgres and Snowflake Peers

--- a/usecases/real-time-cdc/postgres-to-azure-eventhubs.mdx
+++ b/usecases/real-time-cdc/postgres-to-azure-eventhubs.mdx
@@ -2,6 +2,10 @@
 title: "PostgreSQL To Azure Event Hubs"
 ---
 
+<Warning>
+Azure Event Hubs as a destination is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 Let's look at how we can seamlessly perform Change-Data Capturing (CDC) from PostgreSQL to topics in Azure EventHubs.
 
 ### Scenario

--- a/usecases/real-time-cdc/postgres-to-bigquery.mdx
+++ b/usecases/real-time-cdc/postgres-to-bigquery.mdx
@@ -2,6 +2,10 @@
 title: "PostgreSQL to BigQuery"
 ---
 
+<Warning>
+BigQuery as a **destination** is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination. Note that BigQuery remains a **supported source**.
+</Warning>
+
 ### Scenario
 
 Suppose you have a banking application running on PostgreSQL. There are two tables: "users" and "transactions." You want to sync these tables in real-time to BigQuery for analytics purposes, such as real-time fraud detection. Let's see how we can make this happen within a few minutes and a few SQL commands using PeerDB.

--- a/usecases/real-time-cdc/postgres-to-cloud.mdx
+++ b/usecases/real-time-cdc/postgres-to-cloud.mdx
@@ -2,6 +2,10 @@
 title: "PostgreSQL To AWS S3 And Google Cloud Storage"
 ---
 
+<Warning>
+S3 and GCS as destinations are deprecated and no longer actively maintained. They remain fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 PeerDB support Change-Data-Capture (CDC) from PostgreSQL to S3 and GCS buckets in the form of AVRO files in the destination.
 We utilise the interoperability between GCS and S3 here.
 

--- a/usecases/real-time-cdc/postgres-to-snowflake.mdx
+++ b/usecases/real-time-cdc/postgres-to-snowflake.mdx
@@ -2,6 +2,10 @@
 title: "PostgreSQL To Snowflake"
 ---
 
+<Warning>
+Snowflake as a destination is deprecated and no longer actively maintained. It remains fully functional and no code is currently being removed. For new mirrors, we recommend ClickHouse, ClickHouse Cloud, or Postgres as the destination.
+</Warning>
+
 Let's look at how we can seamlessly perform Change-Data Capturing (CDC) from PostgreSQL to Snowflake.
 
 ### Scenario

--- a/usecases/streaming-query-replication/overview.mdx
+++ b/usecases/streaming-query-replication/overview.mdx
@@ -2,6 +2,10 @@
 title: "Overview"
 ---
 
+<Warning>
+Streaming Query Replication (QRep), including XMIN-based replication, is a deprecated mirror type and no longer actively maintained. It remains fully functional and no code is currently being removed. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors.
+</Warning>
+
 PeerDB introduces the **CREATE MIRROR FOR SELECT** SQL command for continuous sync of data from PostgreSQL to the desired target Peer based on any SELECT query on PostgreSQL. This command allows you to perform a pre-transform of the data on the source before syncing it to the target.
 Currently we support **ClickHouse**, **PostgreSQL (running anywhere)**, **AWS S3**, **BigQuery** and **Snowflake** as the target Peers.
 

--- a/usecases/streaming-query-replication/postgres-to-bigquery.mdx
+++ b/usecases/streaming-query-replication/postgres-to-bigquery.mdx
@@ -2,6 +2,10 @@
 title: "PostgreSQL to BigQuery"
 ---
 
+<Warning>
+Streaming Query Replication (QRep) is a deprecated mirror type and no longer actively maintained. It remains fully functional and no code is currently being removed. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors. BigQuery as a destination is also deprecated, though BigQuery remains a supported source.
+</Warning>
+
 ### Scenario
 
 Let's consider a scenario where we have an events table in PostgreSQL. We want to periodically sync data from this table in PostgreSQL to BigQuery. However, we only want to sync a few columns filtered based on the country (USA) and create a single denormalized view of the data in BigQuery. Let's see how we can achieve this within a few minutes and a few SQL commands using PeerDB.

--- a/usecases/streaming-query-replication/postgres-to-postgres.mdx
+++ b/usecases/streaming-query-replication/postgres-to-postgres.mdx
@@ -2,6 +2,10 @@
 title: "PostgreSQL to PostgreSQL"
 ---
 
+<Warning>
+Streaming Query Replication (QRep) is a deprecated mirror type and no longer actively maintained. It remains fully functional and no code is currently being removed. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors.
+</Warning>
+
 ### Step 1: CREATE Two Postgres Peers
 
     There is a guide available for creating a PostgreSQL peer here: [CREATE Postgres PEER](/sql/commands/create-peer#postgresql-peer)

--- a/usecases/streaming-query-replication/postgres-to-s3.mdx
+++ b/usecases/streaming-query-replication/postgres-to-s3.mdx
@@ -2,6 +2,10 @@
 title: "PostgreSQL to S3"
 ---
 
+<Warning>
+Streaming Query Replication (QRep) is a deprecated mirror type and no longer actively maintained. It remains fully functional and no code is currently being removed. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors. S3 as a destination is also deprecated.
+</Warning>
+
 PeerDB can stream your PostgreSQL data to your S3 bucket in the form of `.avro` files. Please **fill in your AWS credentials** in [PeerDB's docker-compose file](https://github.com/PeerDB-io/peerdb/blob/e9fe3e03e242abc37a7526d7132c1f7232e00e5f/docker-compose.yml#L89-L91C36) before running it.
 
 ### Step 1: CREATE Postgres and S3 Peers

--- a/usecases/streaming-query-replication/postgres-to-snowflake.mdx
+++ b/usecases/streaming-query-replication/postgres-to-snowflake.mdx
@@ -2,6 +2,10 @@
 title: "PostgreSQL to Snowflake"
 ---
 
+<Warning>
+Streaming Query Replication (QRep) is a deprecated mirror type and no longer actively maintained. It remains fully functional and no code is currently being removed. We recommend [CDC (Change Data Capture)](/usecases/real-time-cdc/overview) as the actively-maintained mirror type for new mirrors. Snowflake as a destination is also deprecated.
+</Warning>
+
 ### Scenario
 
 Let's consider a scenario where we have an "events" table and a "users" table in PostgreSQL. We want to periodically sync data from these two tables in PostgreSQL to Snowflake. However, we only want to sync a few columns filtered based on the country (USA) and create a single denormalized view of the data in Snowflake. Let's see how we can achieve this within a few minutes and a few SQL commands using PeerDB.


### PR DESCRIPTION
This documentation PR accompanies PeerDB-io/peerdb#4491.

It adds concise deprecation callouts (no content removed or restructured) to mark the following as deprecated and no longer actively maintained. They remain fully functional and no code is currently being removed.

## Deprecated destination connectors
- Snowflake
- ElasticSearch
- Kafka (including the Confluent and Redpanda variants)
- Azure Event Hubs
- Google Pub/Sub
- S3
- GCS
- BigQuery — deprecated **only as a destination**. BigQuery remains a **supported source**.

Actively-maintained destinations: ClickHouse, ClickHouse Cloud, Postgres.

## Deprecated mirror types
- Query Replication (QRep)
- XMIN

CDC (Change Data Capture) is the recommended, actively-maintained mirror type.

## Pages updated
- Connector setup guides: `connect/snowflake`, `connect/bigquery`, `connect/s3`, `connect/gcs`, `connect/elasticsearch`, `connect/kafka`, `connect/confluent-cloud`, `connect/pubsub`
- CDC mirror guides to deprecated destinations: `mirror/cdc-pg-sf`, `mirror/cdc-pg-bq`, `mirror/cdc-pg-kafka`, `mirror/cdc-pg-elasticsearch`
- CDC use-case pages to deprecated destinations: `usecases/real-time-cdc/postgres-to-snowflake`, `postgres-to-bigquery`, `postgres-to-cloud` (S3/GCS), `postgres-to-azure-eventhubs`
- Streaming Query Replication (QRep): `usecases/streaming-query-replication/overview` and all sub-pages, plus `tutorials/realtime-streaming-of-query-results`
- SQL command reference: `sql/commands/create-mirror` (Streaming Query Results and XMIN sections)
- Status/matrix pages: `features/supported-connectors`, `sql/commands/supported-connectors`, `features/feature-matrix` (rows marked _(deprecated)_ and a summary callout added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)